### PR TITLE
initial review of global params

### DIFF
--- a/global-parameters-android.md
+++ b/global-parameters-android.md
@@ -1,0 +1,687 @@
+# Global Parameters - Android
+
+This page documents various global parameters you can set on the Prebid SDK. It describes the properties and methods of the Prebid SDK that allow you to supply important parameters to the header bidding auction.
+
+## Prebid Global Properties and Methods
+
+The `Prebid` class is a singleton that enables you to apply global settings. It covers:
+
+- attributes that are defined during initialization (e.g. the Prebid Server connection)
+- values affecting the behavior of the Prebid SDK (e.g. timeout)
+- items influencing the OpenRTB output (e.g. shareGeoLocation)
+
+### Global Properties
+
+(TBD - where are these set? Need an example. )
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Purpose | Description | Example |
+| --- | --- | --- | --- | --- |
+| isCoppaEnabled | optional | boolean | ORTB | Set this to true if this app is aimed at children. It sets the ORTB COPPA flag. Default is false. | `true` |
+| useExternalBrowser | optional | boolean | ORTB | TBD? Defaults to `false`. | `true` |
+| sendMraidSupportParams | optional | boolean | ORTB | TBD If `true`, the SDK sends "af=3,5", indicating support for MRAID. Defaults to `true`. | `false` |
+
+### Global Methods
+
+#### setPrebidServerAccountId()
+
+Your Prebid Server team will tell you whether this is required or not and if so, the value. See the initialization page for [Android](/prebid-mobile/pbm-api/android/code-integration-android.html).
+
+#### setPrebidServerHost()
+
+This is where the Prebid SDK will send the auction information.
+
+Signature:
+
+```kotlin
+func setPrebidServerHost(host: String)
+```
+
+Parameters: 
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| host | required | object | Host.APPNEXUS, Host.RUBICON, Host.createCustomHost(PREBID_SERVER_AUCTION_ENDPOINT) | Host.createCustomHost<wbr>("https://prebidserver<wbr>.example.com<wbr>/openrtb2/auction") |
+
+Examples:
+
+```kotlin
+PrebidMobile.setPrebidServerHost(Host.APPNEXUS)
+PrebidMobile.setPrebidServerHost(Host.RUBICON)
+PrebidMobile.setPrebidServerHost(Host.createCustomHost(https://prebidserver.example.com/openrtb2/auction))
+```
+
+#### setCustomStatusEndpoint()
+
+Signature:
+
+```kotlin
+    public static void setCustomStatusEndpoint(String url) {
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| url | required | string | Use this URL to check the status of Prebid Server. The default status endpoint is the PBS URL appended with '/status'. | "https://prebidserver<wbr>.example<wbr>.com/custom<wbr>/status" |
+
+#### setTimeoutMillis()
+
+The Prebid SDK timeout. When this number of milliseconds passes, the Prebid SDK returns control to the ad server SDK to fetch an ad without Prebid bids. See the initialization page for [Android](/prebid-mobile/pbm-api/android/code-integration-android.html).
+
+#### setShareGeoLocation()
+
+If this flag is true AND the app collects the user’s geographical location data, Prebid Mobile will send the user’s lat/long geographical location data to the Prebid Server. The default is false.
+
+#### setIncludeWinnersFlag()
+
+If `true`, Prebid sdk will add the `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . This is needed if you've set up line items in an ad server in "Send Top Bid" mode, as it's what creates the key value pairs like `hb_pb`. 
+
+Signature:
+
+```kotlin
+    public static void setIncludeWinnersFlag(boolean includeWinners)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| includeWinners | required | boolean | If `true`, Prebid sdk will add `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
+
+#### setIncludeBidderKeysFlag()
+
+If `true`, Prebid sdk will add the `includebidderkeys` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . This is needed if you've set up line items in an ad server in "Send All Bids" mode, as it's what creates the key value pairs like `hb_pb_bidderA`. 
+
+Signature:
+
+```kotlin
+    public static boolean setIncludeBidderKeysFlag(boolean includeBidderKeys) {
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| includeBidderKeys | required | boolean | If `true`, Prebid sdk will add `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
+
+#### setStoredAuctionResponse()
+
+For testing and debugging. Get this value from your Prebid Server team. It signals Prebid Server to respond with a static response from the Prebid Server Database. 
+See [more information on stored auction responses](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses).
+
+Signature:
+
+```kotlin
+public static void setStoredAuctionResponse(@Nullable String storedAuctionResponse)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| storedAuctionResponse | required | string | Key as defined by Prebid Server. Get this value from your Prebid Server team. | "abc123-sar-test-320x50" |
+
+#### addStoredBidResponse()
+
+Stored Bid Responses are for testing and debugging similar to Stored Auction Responses (see the Global Properties above). They signal Prebid Server to respond with a static pre-defined response, except Stored Bid Responses actually exercise the bidder adapter. For more information on how stored bid responses work, refer to the [Prebid Server endpoint doc](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses). Your Prebid Server team will help you determine how best to setup test and debug.
+
+Signature:
+
+```kotlin
+void addStoredBidResponse(String bidder, String responseId)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| bidder | required | string | Bidder name as defined by Prebid Server | "bidderA" |
+| responseId | required | string | ID used in the Prebid Server Database. Get this value from your Prebid Server team. | "abc123-sbr-test-300x250" |
+
+#### clearStoredBidResponses()
+
+This method clears any stored bid responses. It doesn’t take any parameters.
+
+Signature:
+
+```kotlin
+void clearStoredBidResponses()
+```
+
+Parameters: none.
+
+#### setLogLevel
+
+Controls the level of logging output to the console.
+
+Signature:
+
+```kotlin
+    public static void setLogLevel(LogLevel logLevel)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| logLevel | required | enum | The value can be ERROR, DEBUG, WARN, and NONE. The default is `.NONE`. | `.DEBUG` |
+
+#### setPbsDebug()
+
+Adds the debug flag (`test`:1) on the outbound http call to the Prebid Server. The `test` flag signals to the Prebid Server to emit the full resolved request and the full Bid Request and Bid Response to and from each bidder.
+
+Signature:
+
+```kotlin
+public static void setPbsDebug(boolean pbsDebug)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| pbsDebug | required | boolean | Turn on/off debug mode. Defaults to `false`. | `true` |
+
+#### assignNativeAssetID()
+
+Whether to automatically assign an assetID for a Native ad. Default is `false`.
+
+Signature:
+
+```kotlin
+    public static void assignNativeAssetID(boolean assignNativeAssetID) {
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| assignNativeAssetID | required | boolean | Whether to automatically assign an assetID for a Native ad. Defaults to `false`. | `true` |
+
+#### setCreativeFactoryTimeout()
+
+Controls how long a banner creative has to load before it is considered a failure.
+
+Signature:
+
+```kotlin
+    public static void setCreativeFactoryTimeout(int creativeFactoryTimeout)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| creativeFactoryTimeout | required | integer | Controls how long a banner creative has to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+
+#### setCreativeFactoryTimeoutPreRenderContent()
+
+Controls how much time video and interstitial creatives have to load before it is considered a failure.
+
+Signature:
+
+```kotlin
+    public static void setCreativeFactoryTimeoutPreRenderContent(int creativeFactoryTimeoutPreRenderContent)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| creativeFactoryTimeoutPreRenderContent | required | integer | Controls how much time video and interstitial creatives have to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+
+#### setCustomHeaders()
+
+This method enables you to customize the HTTP call to Prebid Server.
+
+Signature:
+
+```kotlin
+    public static void setCustomHeaders(@Nullable HashMap<String, String> customHeaders)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| customHeaders | required | hashmap | Hashmap of custom headers | "X-mycustomheader: customvalue" |
+
+#### setCustomLogger()
+
+TBD
+
+Signature:
+
+```kotlin
+    public static void setCustomLogger(@NonNull PrebidLogger logger)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| logger | required | ? | TBD | TBD |
+
+## Consent Management
+
+This section describes how app developers can provide info on user consent to the Prebid SDK and how SDK behaves under different kinds of restrictions.
+
+### GDPR
+
+There are two ways to provide information on user consent to the Prebid SDK according to the [IAB's Transparency & Consent Framework (TCF)](https://iabeurope.eu/understanding-the-upcoming-transparency-consent-framework-v2-2/)
+
+- Explicitly via Prebid SDK API: publishers can provide TCF data via Prebid SDK’s Targeting API
+- Implicitly set through the CMP: Prebid SDK reads the TCF data stored in the `UserDefaults`. This is the preferred approach.
+
+**Important**: The Prebid SDK explicitly prioritizes the values set through the API over those stored by the CMP.  If the publisher provides TCF data both ways, the values set through the API will be sent to the PBS, and values stored by the CMP will be ignored. 
+
+#### Setting GDPR Values with the API
+
+Prebid SDK provides three properties to set TCF consent values explicitly, though this method is not preferred. Ideally, the Consent Management Platform will set these values – see the next section.
+
+If you need to set the values directly, here's how to indicate that the user is subject to GDPR:
+
+```kotlin
+Targeting.setSubjectToGDPR(true)
+```
+
+To provide the consent string:
+
+```kotlin
+Targeting.setGDPRConsentString("BOMyQRvOMyQRvABABBAAABAAAAAAEA")
+```
+
+To set the purpose consent: 
+
+```kotlin
+Targeting.setPurposeConsents("100000000000000000000000")
+```
+
+See also the API references for isSubjectToGDPR(), getGDPRConsentString(), getPurposeConsent(int index), getPurposeConsents(), getDeviceAccessConsent()
+
+#### Getting Consent Values from the CMP
+
+Prebid SDK reads the values for the following keys from the `SharedPreferences` object:
+
+- **IABTCF_gdprApplies** - indicates whether the user is subject to GDPR
+- **IABTCF_TCString** - full encoded TC string
+- **IABTCF_PurposeConsents** - indicates the consent status for the purpose. 
+
+For more detailed information, read the [In-App Details section](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details) of the TCF.
+
+**Note**: Publishers shouldn’t explicitly assign values for these keys (unless they have a custom-developed CMP).  It is a privilege of the Consent Management Provider (CMP) SDKs. If the publisher wants to provide this data to the Prebid SDK, they should use the explicit APIs described above.
+
+Here's how Prebid SDK processes CMP values:
+
+- It reads CMP values during the initialization and on each bid request, so the latest value is always used.
+- It doesn’t verify or validate CMP values in any way
+
+### CCPA / USP
+
+The California Consumer Protection Act drove the IAB to implement the "US Privacy" protocol.
+
+Prebid SDK reads and sends USP/CCPA signals according to the [US Privacy User Signal Mechanism](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/USP%20API.md) and [OpenRTB extension](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/7f4f1b2931cca03bd4d91373bbf440071823f257/CCPA/OpenRTB%20Extension%20for%20USPrivacy.md). 
+
+Prebid SDK reads the value for the `IABUSPrivacy_String` key from `SharedPreferences` and sends it in the `regs.ext.us_privacy` object of the OpenRTB request.
+
+### COPPA
+
+The Children's Online Privacy Protection Act of the United States is a way for content producers to declare their content is aimed at children, which invokes additional privacy protections.
+
+Prebid SDK follows the OpenRTB 2.6 spec and provides an API to indicate whether the current content falls under COPPA regulation. Publishers can set the respective flag using the targeting API: 
+
+```kotlin
+Targeting.setSubjectToCOPPA(true)
+```
+
+Prebid SDK passes this flag in the `regs.coppa` object of the bid requests.
+
+If you're app developer setting this COPPA flag, we recommend you also:
+
+- set the `shareGeoLocation` property to false
+- avoid passing any sensitive first party data
+
+### GPP
+
+A Consent Management Platform (CMP) utilizing [IAB's Global Privacy Protocol](https://iabtechlab.com/gpp/) is a comprehensive way for apps to manage user consent across multiple regulatory environments.
+
+Since version 2.0.6, Prebid SDK reads and sends GPP signals:
+
+- The GPP string is read from IABGPP_HDR_GppString in `SharedPreferences`. It is sent to Prebid Server on `regs.gpp`.
+- The GPP Section ID is likewise read from IABGPP_GppSID. It is sent to Prebid Server on `regs.gpp_sid`.
+
+## First Party Data
+
+First Party Data (FPD) is information about the app or user known by the developer that may be of interest to advertisers. 
+
+- User FPD includes details about a specific user like "frequent user" or "job title". This data if often subject to regulatory control, so needs to be specified as user-specific data. Note that some attributes like health status are limited in some regions. App developers are strongly advised to speak with their legal counsel before passing User FPD.
+- Inventory FPD includes details about the particular part of the app where the ad will displayed like "sports/basketball" or "editor 5-star rating".
+
+### User FPD
+
+Prebid SDK provides following functions to manage First Party User Data:
+
+```kotlin
+void addUserData(String key, String value)
+
+void updateUserData( String key, Set<String> value)
+
+void removeUserData(String key)
+
+void clearUserData()
+
+Map<String, Set<String>> getUserDataDictionary() {
+
+void addUserKeywords(Set<String> keywords) {
+
+void removeUserKeyword(String keyword) {
+
+void clearUserKeywords() {
+
+String getUserKeywords() {
+
+Set<String> getUserKeywordsSet() {
+```
+
+Example:
+
+```kotlin
+TargetingParams.addUserData("globalUserDataKey1", "globalUserDataValue1")
+```
+
+### Inventory FPD
+
+Prebid provides following functions to manage First Party Inventory Data:
+
+```kotlin
+void addExtData(String key, String value)
+
+void updateExtData(String key, Set<String> value)
+
+void removeExtData(String key)
+
+Map<String, Set<String>> getExtDataDictionary()
+
+void addExtKeyword(String keyword)
+
+void addExtKeywords(Set<String> keywords)
+
+void removeExtKeyword(String keyword)
+
+void clearExtKeywords()
+
+Set<String> getExtKeywordsSet()
+```
+
+Example:
+
+```kotlin
+Targeting.addExtData("globalContextDataKey1", "globalContextDataValue1")
+```
+
+### Controlling Bidder Access to FPD
+
+Prebid Server will let you control which bidders are allowed access to First Party Data. Prebid SDK collects this an Access Control List with the following methods:
+
+```kotlin
+void addBidderToAccessControlList(String bidderName)
+
+void removeBidderFromAccessControlList(String bidderName)
+
+void clearAccessControlList()
+
+Set<String> getAccessControlList()
+```
+
+Example:
+
+```kotlin
+Targeting.addBidderToAccessControlList("bidderA")
+```
+
+## User Identity
+
+Mobile apps traditionally rely on IDFA-type device IDs for advertising, but there are other User ID systems available to app developers and more will be made available in the future. Prebid SDK supports two ways to maintain Extended User ID (EID) details:
+
+- A global property - in this approach, the app developer sets the IDs while initializing the Prebid SDK. This data persists only for the user session.
+- Local storage - the developer can choose to store the IDs persistently in local storage and Prebid SDK will utilize them on each bid request.
+
+Any identity vendor's details in local storage will be sent to Prebid Server unadulterated. If user IDs are set both in the property and entered into local storage, the property data will prevail.
+
+{: .alert.alert-info :}
+Note that the phrase "EID" stands for "Extended IDs" in [OpenRTB 2.6](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md), but for historic reasons, Prebid SDK methods use the word "external" rather than "extended".
+
+### Prebid SDK API Access
+
+Prebid SDK supports passing an array of EIDs at auction time with the function storeExternalUserId, which is globably scoped. It is sufficient to set the externalUserIdArray object once per user session, as these values would be used in all consecutive ad auctions in the same session.
+
+```kotlin
+void storeExternalUserId(<ExternalUserId> externalUserIds)
+
+List<ExternalUserId> fetchStoredExternalUserIds()
+
+ExternalUserId fetchStoredExternalUserId(@NonNull String source) 
+
+void removeStoredExternalUserId(@NonNull String source) {
+
+void clearStoredExternalUserIds() {
+```
+
+Example:
+
+```kotlin
+  // User Id from External Third Party Sources
+  ArrayList<ExternalUserId> externalUserIdArray = new ArrayList<>();
+  externalUserIdArray.add(new ExternalUserId("adserver.org", "111111111111", null, new HashMap() {
+    {
+        put ("rtiPartner", "TDID");
+    }
+}));
+
+  externalUserIdArray.add(new ExternalUserId("netid.de", "999888777", null, null));
+  externalUserIdArray.add(new ExternalUserId("criteo.com", "_fl7bV96WjZsbiUyQnJlQ3g4ckh5a1N", null, null));
+  externalUserIdArray.add(new ExternalUserId("liveramp.com", "AjfowMv4ZHZQJFM8TpiUnYEyA81Vdgg", null, null));
+  externalUserIdArray.add(new ExternalUserId("sharedid.org", "111111111111", 1, null));
+}));
+
+//Set External User IDs
+PrebidMobile.storeExternalUserId(externalUserIdArray);
+```
+
+## Other Targeting Values
+
+There are several other fields app developers may want to set to give bidders additional information about the auction.
+
+### Methods
+
+#### setYearOfBirth()
+
+Sets the user's year of birth for buyers to be able to target age ranges.
+
+Signature:
+
+```kotlin
+void setYearOfBirth(int yob)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| yob | required | integer | User's year of birth. | 1990 |
+
+See also the API references for getYearOfBirth(), clearYearOfBirth(), and setUserAge().
+
+#### setGender()
+
+Sets the user's gender for buyer targeting. It's incumbent upon to the app developer to make sure they have permission to read this data. Prebid Server may remove it under some privacy scenarios.
+
+Signature:
+
+```kotlin
+void setGender(GENDER gender)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| gender | required | enum | Valid values are MALE, FEMALE, and UNKNOWN. Defaults to UNKNOWN. | MALE |
+
+See also the API reference for getGender().
+
+#### setUserLatLng()
+
+Sets the device location for buyer targeting. It's incumbent upon to the app developer to make sure they have permission to read this data. Prebid Server may remove it under some privacy scenarios.
+
+Signature:
+
+```kotlin
+void setUserLatLng( Float latitude, Float longitude)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| latitude | required | double | The device latitude. | 40.71 |
+| longitude | required | double | The device longitude. | 74.01 |
+
+#### setPublisherName()
+
+Define the OpenRTB app.publisher.name field.
+
+Signature:
+
+```kotlin
+void setPublisherName(String publisherName)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| publisherName | required | string | Publisher name | "publisher 1" |
+
+See also the API reference for getPublisherName().
+
+#### setDomain()
+
+Define the OpenRTB app.domain field.
+
+Signature:
+
+```kotlin
+void setDomain(String domain)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| domain | required | string | Domain | "example.com" |
+
+See also the API reference for getDomain().
+
+#### setStoreUrl()
+
+Define the OpenRTB app.storeurl field.
+
+Signature:
+
+```kotlin
+void setStoreUrl(String storeUrl)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| storeUrl | required | string | App store URL | TBD |
+
+See also the API reference for getStoreUrl().
+
+#### setBundleName()
+
+Define the OpenRTB app.storeurl field.
+
+Signature:
+
+```kotlin
+void setBundleName(String bundleName) {
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| bundleName | required | string | App bundle name | TBD |
+
+See also the API reference for getBundleName().
+
+#### setOmidPartnerName()
+
+Define the OpenRTB source.ext.omidpn field.
+
+Signature:
+
+```kotlin
+setOmidPartnerName(@Nullable String omidPartnerName)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| omidPartnerName | required | string | Open Measurement Partner name | "MyIntegrationPartner" |
+
+See also the API reference for getOmidPartnerName().
+
+#### setOmidPartnerVersion()
+
+Define the OpenRTB source.ext.omidpv field.
+
+Signature:
+
+```kotlin
+setOmidPartnerVersion(@Nullable String omidPartnerVersion)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| omidPartnerVerson | required | string | Open Measurement Partner version | "7.1" |
+
+See also the API reference for getOmidPartnerVersion().
+
+TBD
+    public static void setUserCustomData(@Nullable String data) {
+    public static String getUserCustomData() {
+    public static void setUserId(String userId) {
+    public static String getUserId() {
+    public static void setUserExt(Ext ext) {
+    public static Ext getUserExt() {

--- a/global-parameters-ios.md
+++ b/global-parameters-ios.md
@@ -1,4 +1,4 @@
-# Global Parameters
+# Global Parameters - iOS
 
 This page documents various global parameters you can set on the Prebid SDK. It describes the properties and methods of the Prebid SDK that allow you to supply important parameters to the header bidding auction.
 
@@ -12,142 +12,35 @@ The `Prebid` class is a singleton that enables you to apply global settings. It 
 
 ### Global Properties
 
-(TBD - where are these set? Need an example. )
+(TBD - how are these set? Need an example. )
 
 {: .table .table-bordered .table-striped }
 | Parameter | Scope | Type | Purpose | Description | Example |
-| --- | --- | --- | --- | --- |
-| prebidServerAccountId | either | string | init | (iOS only) Your Prebid Server team will tell you whether this is required or not and if so, the value. | "abc123" |
-| prebidServerHost | optional | enum | init | (iOS only) This can take the values "Appnexus", "Rubicon", or "Custom". If "Custom", you need to use the setCustomPrebidServerUrl() method to set a URL. This is where the Prebid SDK will send the auction information. Your Prebid Server team will tell you which value to use. The default is "Custom". | "Custom" |
-| customStatusEndpoint | optional | string | init | (iOS only) Use this URL to check the status of Prebid Server. The default status endpoint is the PBS URL appended with '/status'. | "https://prebidserver<wbr>.example<wbr>.com/custom<wbr>/status" |
-| shareGeoLocation | optional | boolean | ORTB | (iOS only) If this flag is true AND the app collects the user’s geographical location data, Prebid Mobile will send the user’s lat/long geographical location data to the Prebid Server. The default is false. | `true` |
+| --- | --- | --- | --- | --- | --- |
+| prebidServerAccountId | either | string | init | Your Prebid Server team will tell you whether this is required or not and if so, the value. | "abc123" |
+| prebidServerHost | optional | enum | init | This can take the values "Appnexus", "Rubicon", or "Custom". If "Custom", you need to use the setCustomPrebidServerUrl() method to set a URL. This is where the Prebid SDK will send the auction information. Your Prebid Server team will tell you which value to use. The default is "Custom". | "Custom" |
+| customStatusEndpoint | optional | string | init | Use this URL to check the status of Prebid Server. The default status endpoint is the PBS URL appended with '/status'. | "https://prebidserver<wbr>.example<wbr>.com/custom<wbr>/status" |
+| shareGeoLocation | optional | boolean | ORTB | If this flag is true AND the app collects the user’s geographical location data, Prebid Mobile will send the user’s lat/long geographical location data to the Prebid Server. The default is false. | `true` |
 | locationUpdatesEnabled | optional | boolean | ORTB | If true, the SDK will periodically try to listen for location updates. Default is `false`. | `true` |
-| logLevel | optional | enum | SDK control | (iOS only) This property controls the level of logging output to the console. The value can be .error, .info, .debug, .verbose, .warn, .severe, and .info. The default is `.debug`. | `.error` |
+| logLevel | optional | enum | SDK control | This property controls the level of logging output to the console. The value can be .error, .info, .debug, .verbose, .warn, .severe, and .info. The default is `.debug`. | `.error` |
 | debugLogFileEnabled | optional | boolean | SDK control | If set to true, the output of PrebidMobile's internal logger is written to a text file. Default is `false`. | `true` |
-| timeoutMillis | optional | integer | init | (iOS only) (SDK v1.2+) The Prebid SDK timeout. When this number of milliseconds passes, the Prebid SDK returns control to the ad server SDK to fetch an ad without Prebid bids. | 1000 |
-| creativeFactoryTimeout | optional | integer | SDK control | (iOS only) Controls how long a banner creative has to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
-| creativeFactoryTimeoutPreRenderContent | optional | integer | SDK control | (iOS only) Controls how much time video and interstitial creatives have to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
-| storedAuctionResponse | optional | string | ORTB | (iOS only) For testing and debugging. Get this value from your Prebid Server team. It signals Prebid Server to respond with a static response from the Prebid Server Database. See [more information on stored auction responses](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses). | "abc123-sar-test-320x50" |
-| pbsDebug | optional | boolean | ORTB | (iOS only) Adds the debug flag (`test`:1) on the outbound http call to the Prebid Server. The `test` flag signals to the Prebid Server to emit the full resolved request and the full Bid Request and Bid Response to and from each bidder. | true |
-| shouldAssignNativeAssetID | optional | boolean | ORTB | (iOS only) Whether to automatically assign an assetID for a Native ad. Default is `false`. | true |
+| timeoutMillis | optional | integer | init | (SDK v1.2+) The Prebid SDK timeout. When this number of milliseconds passes, the Prebid SDK returns control to the ad server SDK to fetch an ad without Prebid bids. | 1000 |
+| creativeFactoryTimeout | optional | integer | SDK control | Controls how long a banner creative has to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+| creativeFactoryTimeoutPreRenderContent | optional | integer | SDK control | Controls how much time video and interstitial creatives have to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+| storedAuctionResponse | optional | string | ORTB | For testing and debugging. Get this value from your Prebid Server team. It signals Prebid Server to respond with a static response from the Prebid Server Database. See [more information on stored auction responses](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses). | "abc123-sar-test-320x50" |
+| pbsDebug | optional | boolean | ORTB | Adds the debug flag (`test`:1) on the outbound http call to the Prebid Server. The `test` flag signals to the Prebid Server to emit the full resolved request and the full Bid Request and Bid Response to and from each bidder. | true |
+| shouldAssignNativeAssetID | optional | boolean | ORTB | Whether to automatically assign an assetID for a Native ad. Default is `false`. | true |
 | useCacheForReportingWithRenderingAPI | optional | boolean | ORTB | Indicates whether PBS should cache the bid on the server side. If the value is `true` the Prebid SDK will make the cache request to retrieve the cached asset. Default is `false`. | true |
-| useExternalClickthroughBrowser | optional | boolean | SDK control | (iOS only) Controls whether to use PrebidMobile's in-app browser or the Safari App for displaying ad clickthrough content. Default is false. | true |
-| useExternalClickthroughBrowser | optional | enum | ORTB | (iOS only) Indicates the type of browser opened upon clicking the creative in an app. This corresponds to the OpenRTB imp.clickbrowser field. Values are "embedded" and "native". Default is "native". | "native".
-| includeWinners | optional | boolean | ORTB | (iOS only) If `true`, Prebid sdk will add `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
-| includeBidderKeys | optional | boolean | ORTB | (iOS only) If `true`, Prebid sdk will add `includebidderkeys` flag inside the targeting object described in [PBS Documentation](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
-| isCoppaEnabled | optional | boolean | ORTB | (Android only) Set this to true if this app is aimed at children. It sets the ORTB COPPA flag. Default is false. | `true` |
-| useExternalBrowser | optional | boolean | ORTB | (Android only) TBD? Defaults to `false`. | `true` |
-| sendMraidSupportParams | optional | boolean | ORTB | (Android only) TBD If `true`, the SDK sends "af=3,5", indicating support for MRAID. Defaults to `true`. | `false` |
+| useExternalClickthroughBrowser | optional | boolean | SDK control | Controls whether to use PrebidMobile's in-app browser or the Safari App for displaying ad clickthrough content. Default is false. | true |
+| impClickbrowserType | optional | enum | ORTB | Indicates the type of browser opened upon clicking the creative in an app. This corresponds to the OpenRTB imp.clickbrowser field. Values are "embedded" and "native". Default is "native". | "native".
+| includeWinners | optional | boolean | ORTB | If `true`, Prebid sdk will add `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
+| includeBidderKeys | optional | boolean | ORTB | If `true`, Prebid sdk will add `includebidderkeys` flag inside the targeting object described in [PBS Documentation](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
 
 ### Global Methods
 
-#### setPrebidServerAccountId() (Android only)
+#### setCustomPrebidServerUrl()
 
-Your Prebid Server team will tell you whether this is required or not and if so, the value. See the initialization page for [Android](/prebid-mobile/pbm-api/android/code-integration-android.html).
-
-#### setPrebidServerHost()  (Android only)
-
-This is where the Prebid SDK will send the auction information.
-
-Signature:
-
-```kotlin
-func setPrebidServerHost(host: String)
-```
-
-Parameters: 
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| host | required | object | Host.APPNEXUS, Host.RUBICON, Host.createCustomHost(PREBID_SERVER_AUCTION_ENDPOINT) | Host.createCustomHost<wbr>("https://prebidserver<wbr>.example.com<wbr>/openrtb2/auction") |
-
-Examples:
-
-```kotlin
-PrebidMobile.setPrebidServerHost(Host.APPNEXUS)
-PrebidMobile.setPrebidServerHost(Host.RUBICON)
-PrebidMobile.setPrebidServerHost(Host.createCustomHost(https://prebidserver.example.com/openrtb2/auction))
-```
-
-#### setCustomStatusEndpoint() (Android only)
-
-Signature:
-
-```kotlin
-    public static void setCustomStatusEndpoint(String url) {
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| url | required | string | Use this URL to check the status of Prebid Server. The default status endpoint is the PBS URL appended with '/status'. | "https://prebidserver<wbr>.example<wbr>.com/custom<wbr>/status" |
-
-#### setTimeoutMillis() (Android only)
-
-The Prebid SDK timeout. When this number of milliseconds passes, the Prebid SDK returns control to the ad server SDK to fetch an ad without Prebid bids. See the initialization page for [Android](/prebid-mobile/pbm-api/android/code-integration-android.html).
-
-#### setShareGeoLocation() (Android only)
-
-If this flag is true AND the app collects the user’s geographical location data, Prebid Mobile will send the user’s lat/long geographical location data to the Prebid Server. The default is false.
-
-#### setCustomPrebidServerUrl() (iOS only)
-
-Defines which Prebid Server to connect to. See the initialization pages for [iOS](/prebid-mobile/pbm-api/ios/code-integration-ios.html) or [Android](/prebid-mobile/pbm-api/android/code-integration-android.html).
-
-#### setIncludeWinnersFlag() (Android only)
-
-If `true`, Prebid sdk will add the `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . This is needed if you've set up line items in an ad server in "Send Top Bid" mode, as it's what creates the key value pairs like `hb_pb`. 
-
-Signature:
-
-```kotlin
-    public static void setIncludeWinnersFlag(boolean includeWinners)
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| includeWinners | required | boolean | If `true`, Prebid sdk will add `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
-
-#### setIncludeBidderKeysFlag() (Android only)
-
-If `true`, Prebid sdk will add the `includebidderkeys` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . This is needed if you've set up line items in an ad server in "Send All Bids" mode, as it's what creates the key value pairs like `hb_pb_bidderA`. 
-
-Signature:
-
-```kotlin
-    public static boolean setIncludeBidderKeysFlag(boolean includeBidderKeys) {
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| includeBidderKeys | required | boolean | If `true`, Prebid sdk will add `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
-
-#### setStoredAuctionResponse() (Android only)
-
-For testing and debugging. Get this value from your Prebid Server team. It signals Prebid Server to respond with a static response from the Prebid Server Database. 
-See [more information on stored auction responses](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses).
-
-Signature:
-
-```kotlin
-public static void setStoredAuctionResponse(@Nullable String storedAuctionResponse)
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| storedAuctionResponse | required | string | Key as defined by Prebid Server. Get this value from your Prebid Server team. | "abc123-sar-test-320x50" |
+Defines which Prebid Server to connect to. See the initialization page for [iOS](/prebid-mobile/pbm-api/ios/code-integration-ios.html).
 
 #### addStoredBidResponse()
 
@@ -179,94 +72,9 @@ func clearStoredBidResponses()
 
 Parameters: none.
 
-#### setLogLevel (Android only)
+#### addCustomHeader()
 
-Controls the level of logging output to the console.
-
-Signature:
-
-```kotlin
-    public static void setLogLevel(LogLevel logLevel)
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| logLevel | required | enum | The value can be ERROR, DEBUG, WARN, and NONE. The default is `.NONE`. | `.DEBUG` |
-
-#### setPbsDebug() (Android only)
-
-Adds the debug flag (`test`:1) on the outbound http call to the Prebid Server. The `test` flag signals to the Prebid Server to emit the full resolved request and the full Bid Request and Bid Response to and from each bidder.
-
-Signature:
-
-```kotlin
-public static void setPbsDebug(boolean pbsDebug)
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| pbsDebug | required | boolean | Turn on/off debug mode. Defaults to `false`. | `true` |
-
-#### assignNativeAssetID() (Android only)
-
-Whether to automatically assign an assetID for a Native ad. Default is `false`.
-
-Signature:
-
-```kotlin
-    public static void assignNativeAssetID(boolean assignNativeAssetID) {
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| assignNativeAssetID | required | boolean | Whether to automatically assign an assetID for a Native ad. Defaults to `false`. | `true` |
-
-#### setCreativeFactoryTimeout() (Android only)
-
-Controls how long a banner creative has to load before it is considered a failure.
-
-Signature:
-
-```kotlin
-    public static void setCreativeFactoryTimeout(int creativeFactoryTimeout)
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| creativeFactoryTimeout | required | integer | Controls how long a banner creative has to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
-
-#### setCreativeFactoryTimeoutPreRenderContent() (Android only)
-
-Controls how much time video and interstitial creatives have to load before it is considered a failure.
-
-Signature:
-
-```kotlin
-    public static void setCreativeFactoryTimeoutPreRenderContent(int creativeFactoryTimeoutPreRenderContent)
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| creativeFactoryTimeoutPreRenderContent | required | integer | Controls how much time video and interstitial creatives have to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
-
-#### addCustomHeader() (iOS only)
-
-This method enables you to customize the HTTP call to Prebid Server. See [setCustomHeaders()](TBD) for the Android version.
+This method enables you to customize the HTTP call to Prebid Server.
 
 Signature:
 
@@ -282,23 +90,6 @@ Parameters:
 | name | required | string | Name of the custom header | "X-mycustomheader" |
 | value | required | string | Value for the custom header | "customvalue" |
 
-#### setCustomHeaders() (Android only)
-
-This method enables you to customize the HTTP call to Prebid Server. See [addCustomHeaders()](TBD) for the iOS version
-
-Signature:
-
-```kotlin
-    public static void setCustomHeaders(@Nullable HashMap<String, String> customHeaders)
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| customHeaders | required | hashmap | Hashmap of custom headers | "X-mycustomheader: customvalue" |
-
 #### clearCustomHeaders()
 
 Allows you to clear any custom headers you have previously set.
@@ -310,23 +101,6 @@ func clearCustomHeaders()
 ```
 
 Parameters: none
-
-#### setCustomLogger() (Android only)
-
-TBD
-
-Signature:
-
-```kotlin
-    public static void setCustomLogger(@NonNull PrebidLogger logger)
-```
-
-Parameters:
-
-{: .table .table-bordered .table-striped }
-| Parameter | Scope | Type | Description | Example |
-| --- | --- | --- | --- | --- |
-| logger | required | ? | TBD | TBD |
 
 ## Consent Management
 
@@ -375,7 +149,7 @@ Targeting.shared.purposeConsents = "100000000000000000000000"
 
 #### Getting Consent Values from the CMP
 
-Prebid SDK reads the values for the following keys from the `UserDefaults` (iOS) or `SharedPreferences` (Android) object:
+Prebid SDK reads the values for the following keys from the `UserDefaults` object:
 
 - **IABTCF_gdprApplies** - indicates whether the user is subject to GDPR
 - **IABTCF_TCString** - full encoded TC string
@@ -396,7 +170,7 @@ The California Consumer Protection Act drove the IAB to implement the "US Privac
 
 Prebid SDK reads and sends USP/CCPA signals according to the [US Privacy User Signal Mechanism](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/USP%20API.md) and [OpenRTB extension](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/7f4f1b2931cca03bd4d91373bbf440071823f257/CCPA/OpenRTB%20Extension%20for%20USPrivacy.md). 
 
-Prebid SDK reads the value for the `IABUSPrivacy_String` key from the `UserDefaults` (iOS) or `SharedPreferences` (Android) and sends it in the `regs.ext.us_privacy` object of the OpenRTB request.
+Prebid SDK reads the value for the `IABUSPrivacy_String` key from the `UserDefaults` and sends it in the `regs.ext.us_privacy` object of the OpenRTB request.
 
 ### COPPA
 
@@ -423,7 +197,7 @@ A Consent Management Platform (CMP) utilizing [IAB's Global Privacy Protocol](ht
 
 Since version 2.0.6, Prebid SDK reads and sends GPP signals:
 
-- The GPP string is read from IABGPP_HDR_GppString in `UserDefaults` (iOS) or `SharedPreferences` (Android). It is sent to Prebid Server on `regs.gpp`.
+- The GPP string is read from IABGPP_HDR_GppString in `UserDefaults`. It is sent to Prebid Server on `regs.gpp`.
 - The GPP Section ID is likewise read from IABGPP_GppSID. It is sent to Prebid Server on `regs.gpp_sid`.
 
 ## First Party Data
@@ -431,7 +205,7 @@ Since version 2.0.6, Prebid SDK reads and sends GPP signals:
 First Party Data (FPD) is information about the app or user known by the developer that may be of interest to advertisers. 
 
 - User FPD includes details about a specific user like "frequent user" or "job title". This data if often subject to regulatory control, so needs to be specified as user-specific data. Note that some attributes like health status are limited in some regions. App developers are strongly advised to speak with their legal counsel before passing User FPD.
-- Inventory FPD includes details about the particular part of the app where the ad will displayed like "sports/basketball" or "editor 5-star rating".
+- Inventory or Contextual FPD includes details about the particular part of the app where the ad will displayed like "sports/basketball" or "editor 5-star rating".
 
 ### User FPD
 
@@ -445,6 +219,16 @@ func updateUserData(key: String, value: Set<String>)
 func removeUserData(forKey: String)
 
 func clearUserData()
+
+func addUserKeyword(_ newElement: String)
+
+func addUserKeywords(_ newElements: Set<String>)
+
+func removeUserKeyword(_ element: String)
+
+func clearUserKeywords()
+
+func getUserKeywords()
 ```
 
 Example:
@@ -458,19 +242,31 @@ Targeting.shared.addUserData(key: "globalUserDataKey1", value: "globalUserDataVa
 Prebid provides following functions to manage First Party Inventory Data:
 
 ```swift
-func addContextData(key: String, value: String)
+func addAppExtData(key: String, value: String)
 
-func updateContextData(key: String, value: Set<String>)
+func updateAppExtData(key: String, value: Set<String>)
 
-func removeContextData(forKey: String)
+func removeAppExtData(for key: String)
 
-func clearContextData()
+func clearAppExtData()
+
+func getAppExtData()
+
+func addAppKeyword(_ newElement: String)
+
+func addAppKeywords(_ newElements: Set<String>)
+
+func removeAppKeyword(_ element: String)
+
+func clearAppKeywords()
+
+func getAppKeywords()
 ```
 
 Example:
 
 ```swift
-Targeting.shared.addContextData(key: "globalContextDataKey1", value: "globalContextDataValue1")
+Targeting.shared.addAppExtData((key: "globalContextDataKey1", value: "globalContextDataValue1")
 ```
 
 ### Controlling Bidder Access to FPD
@@ -491,6 +287,8 @@ Example:
 Targeting.shared.addBidderToAccessControlList(Prebid.bidderNameRubiconProject)
 ```
 
+TBD - replace rubicon with bidderA
+
 ## User Identity
 
 Mobile apps traditionally rely on IDFA-type device IDs for advertising, but there are other User ID systems available to app developers and more will be made available in the future. Prebid SDK supports two ways to maintain User ID details:
@@ -500,9 +298,14 @@ Mobile apps traditionally rely on IDFA-type device IDs for advertising, but ther
 
 Any identity vendor's details in local storage will be sent to Prebid Server unadulterated. If user IDs are set both in the property and entered into local storage, the property data will prevail.
 
+{: .alert.alert-info :}
+Note that the phrase "EID" stands for "Extended IDs" in [OpenRTB 2.6](https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md), but for
+historic reasons, Prebid SDK methods use the word "external" rather than "exte
+nded".
+
 ### Storing IDs in a Property
 
-Prebid SDK supports passing an array of UserID(s) at auction time in the Prebid global field `externalUserIdArray`. Setting the `externalUserIdArray` object once per user session is sufficient unless one of the values changes.
+Prebid SDK supports passing an array of EIDs at auction time in the Prebid global field `externalUserIdArray`. Setting the `externalUserIdArray` object once per user session is sufficient unless one of the values changes.
 
 ```swift
 public var externalUserIdArray = [ExternalUserId]()
@@ -563,3 +366,113 @@ Targeting.shared.removeStoredExternalUserId("sharedid.org")
 //Remove All External UserID
 Targeting.shared.removeStoredExternalUserIds()
 ```
+
+## Other Targeting Values
+
+There are several other fields app developers may want to set to give bidders additional information about the auction.
+
+### Properties
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Platform | Description | Example |
+| --- | --- | --- | --- | --- | --- |
+| contentUrl | optional | string | both | This is the deep-link URL for the app screen that is displaying the ad. This can be an iOS universal link. | |
+| publisherName | optional | string | both | TBD - OpenRTB app.publisher.name | |
+| sourceapp | optional | string | both | TBD - OpenRTB app.name | |
+| storeURL | optional | string | both | TBD - OpenRTB app.storeurl | |
+| domain | optional | string | both | TBD - OpenRTB app.domain | |
+| itunesID | optional | string | both | TBD - OpenRTB app.bundle | |
+| locationPrecision | optional | integer | both | TBD | |
+| omidPartnerName | optional | string | both | | |
+| omidPartnerVersion | optional | string | both | | |
+| userGender | optional | enum | both | "M" = male, "F" = female, "O" = known to be other (i.e., omitted is unknown) | "F" |
+| userID | optional | string | both | TBD - xid? | |
+| userExt | optional | array of strings | both | TBD | |
+| coppa | optional | integer | objC | Defines whether this content is meant for children. 0=false, 1=true. Defaults to false. | 1 |
+| subjectToCOPPA | optional | boolean | swift | Defines whether this content is meant for children. Defaults to false. | `true` |
+| subjectToGDPR | optional | boolean | ? | Defines whether this request is in-scope for European privacy regulations. See [Prebid Server GDPR Support](/prebid-server/features/pbs-privacy.html#gdpr) | `true` |
+| gdprConsentString | optional | string | both | See the [GDPR settings](TBD) section above. | |
+| purposeConsents | optional | string | both | TBD | |
+
+### Methods
+
+#### setYearOfBirth()
+
+Sets the user's year of birth for buyers to be able to target age ranges. It's incumbent upon to the app developer to make sure they have permission to read this data. Prebid Server may remove it under some privacy scenarios.
+
+Signature:
+
+```swift
+func setYearOfBirth(yob: Int)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| yob | required | integer | User's year of birth. | 1990 |
+
+ee also the API reference for getYearOfBirth() and clearYearOfBirth().
+
+#### setSubjectToGDPR()
+
+Manually sets the GDPR scope. It's recommended to use a Consent Management Platform instead of this approach. See the [Getting Consent Values from the CMP](TBD) section above for details.
+
+```swift
+   public func setSubjectToGDPR(gdprFlag: NSNumber)
+``
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| gdprFlag | required | integer | 1=this request is in-scope for GDPR, 0=not in-scope. There's no default. | 1 |
+
+See also the API references for getSubjectToGDPR(), getDeviceAccessConsent(), getDeviceAccessConsentObjc, getPurposeConsent(), isAllowedAccessDeviceData().
+
+#### setLocationPrecision()
+
+TBD
+
+Signature:
+
+```swift
+func setLocationPrecision(precision: NSNumber)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| precision | required | integer | TBD - The device lat/long is rounded off to this many digits of precision.| 2 |
+
+See also the API reference for getLocationPrecision()
+
+#### setLatitude()
+
+Sets the device location for buyer targeting. It's incumbent upon to the app developer to make sure they have permission to read this data. Prebid Server may remove it under some privacy scenarios.
+
+Signature:
+
+```swift
+func setLatitude(latitude: Double, longitude: Double)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| latitude | required | double | The device latitude. | 40.71 |
+| longitude | required | double | The device longitude. | 74.01 |
+
+#### setCustomParams
+
+TBD - what is parameterDictionary? Looks like a mix of user- and inventory-related things.
+
+    public func setCustomParams(_ params: [String : String]?) {
+    public func addCustomParam(_ value: String, withName: String?) {
+

--- a/global-parameters-ios.md
+++ b/global-parameters-ios.md
@@ -1,29 +1,153 @@
-# Global Parameters iOS
+# Global Parameters
 
 This page documents various global parameters you can set on the Prebid SDK. It describes the properties and methods of the Prebid SDK that allow you to supply important parameters to the header bidding auction.
 
 ## Prebid Global Properties and Methods
 
-The `Prebid` class is a singleton that enables you to apply global settings.
+The `Prebid` class is a singleton that enables you to apply global settings. It covers:
+
+- attributes that are defined during initialization (e.g. the Prebid Server connection)
+- values affecting the behavior of the Prebid SDK (e.g. timeout)
+- items influencing the OpenRTB output (e.g. shareGeoLocation)
 
 ### Global Properties
 
-(TBD - where are these set? Need an example. I reformatted this as a table.)
+(TBD - where are these set? Need an example. )
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Purpose | Description | Example |
+| --- | --- | --- | --- | --- |
+| prebidServerAccountId | either | string | init | (iOS only) Your Prebid Server team will tell you whether this is required or not and if so, the value. | "abc123" |
+| prebidServerHost | optional | enum | init | (iOS only) This can take the values "Appnexus", "Rubicon", or "Custom". If "Custom", you need to use the setCustomPrebidServerUrl() method to set a URL. This is where the Prebid SDK will send the auction information. Your Prebid Server team will tell you which value to use. The default is "Custom". | "Custom" |
+| customStatusEndpoint | optional | string | init | (iOS only) Use this URL to check the status of Prebid Server. The default status endpoint is the PBS URL appended with '/status'. | "https://prebidserver<wbr>.example<wbr>.com/custom<wbr>/status" |
+| shareGeoLocation | optional | boolean | ORTB | (iOS only) If this flag is true AND the app collects the user’s geographical location data, Prebid Mobile will send the user’s lat/long geographical location data to the Prebid Server. The default is false. | `true` |
+| locationUpdatesEnabled | optional | boolean | ORTB | If true, the SDK will periodically try to listen for location updates. Default is `false`. | `true` |
+| logLevel | optional | enum | SDK control | (iOS only) This property controls the level of logging output to the console. The value can be .error, .info, .debug, .verbose, .warn, .severe, and .info. The default is `.debug`. | `.error` |
+| debugLogFileEnabled | optional | boolean | SDK control | If set to true, the output of PrebidMobile's internal logger is written to a text file. Default is `false`. | `true` |
+| timeoutMillis | optional | integer | init | (iOS only) (SDK v1.2+) The Prebid SDK timeout. When this number of milliseconds passes, the Prebid SDK returns control to the ad server SDK to fetch an ad without Prebid bids. | 1000 |
+| creativeFactoryTimeout | optional | integer | SDK control | (iOS only) Controls how long a banner creative has to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+| creativeFactoryTimeoutPreRenderContent | optional | integer | SDK control | (iOS only) Controls how much time video and interstitial creatives have to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+| storedAuctionResponse | optional | string | ORTB | (iOS only) For testing and debugging. Get this value from your Prebid Server team. It signals Prebid Server to respond with a static response from the Prebid Server Database. See [more information on stored auction responses](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses). | "abc123-sar-test-320x50" |
+| pbsDebug | optional | boolean | ORTB | (iOS only) Adds the debug flag (`test`:1) on the outbound http call to the Prebid Server. The `test` flag signals to the Prebid Server to emit the full resolved request and the full Bid Request and Bid Response to and from each bidder. | true |
+| shouldAssignNativeAssetID | optional | boolean | ORTB | (iOS only) Whether to automatically assign an assetID for a Native ad. Default is `false`. | true |
+| useCacheForReportingWithRenderingAPI | optional | boolean | ORTB | Indicates whether PBS should cache the bid on the server side. If the value is `true` the Prebid SDK will make the cache request to retrieve the cached asset. Default is `false`. | true |
+| useExternalClickthroughBrowser | optional | boolean | SDK control | (iOS only) Controls whether to use PrebidMobile's in-app browser or the Safari App for displaying ad clickthrough content. Default is false. | true |
+| useExternalClickthroughBrowser | optional | enum | ORTB | (iOS only) Indicates the type of browser opened upon clicking the creative in an app. This corresponds to the OpenRTB imp.clickbrowser field. Values are "embedded" and "native". Default is "native". | "native".
+| includeWinners | optional | boolean | ORTB | (iOS only) If `true`, Prebid sdk will add `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
+| includeBidderKeys | optional | boolean | ORTB | (iOS only) If `true`, Prebid sdk will add `includebidderkeys` flag inside the targeting object described in [PBS Documentation](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
+| isCoppaEnabled | optional | boolean | ORTB | (Android only) Set this to true if this app is aimed at children. It sets the ORTB COPPA flag. Default is false. | `true` |
+| useExternalBrowser | optional | boolean | ORTB | (Android only) TBD? Defaults to `false`. | `true` |
+| sendMraidSupportParams | optional | boolean | ORTB | (Android only) TBD If `true`, the SDK sends "af=3,5", indicating support for MRAID. Defaults to `true`. | `false` |
+
+### Global Methods
+
+#### setPrebidServerAccountId() (Android only)
+
+Your Prebid Server team will tell you whether this is required or not and if so, the value. See the initialization page for [Android](/prebid-mobile/pbm-api/android/code-integration-android.html).
+
+#### setPrebidServerHost()  (Android only)
+
+This is where the Prebid SDK will send the auction information.
+
+Signature:
+
+```kotlin
+func setPrebidServerHost(host: String)
+```
+
+Parameters: 
 
 {: .table .table-bordered .table-striped }
 | Parameter | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
-| prebidServerAccountId | either | string | Your Prebid Server team will tell you whether this is required or not and if so, the value. | "abc123" |
-| prebidServerHost | required | string | This is a URL or system-defined Prebid Server host. It's where the Prebid SDK will send the auction information. Your Prebid Server team will tell you which value to use. The system-defined values are: (TBD) | "https://prebidserver.example.com/openrtb2/auction" |
-| shareGeoLocation | optional | boolean | If this flag is true AND the app collects the user’s geographical location data, Prebid Mobile will send the user’s geographical location data (TBD - lat/long?) to the Prebid Server. The default setting is false. | `true` |
-| logLevel | optional | TBD | This property controls the level of logging output to the console. The value can be (TBD). | TBD |
-| timeoutMillis | optional | integer | (SDK v1.2+) The Prebid SDK timeout. When this number of milliseconds passes, the Prebid SDK returns control to the ad server SDK to fetch an ad without Prebid bids. | 1000 |
-| creativeFactoryTimeout | optional | integer | Controls how long a banner creative has to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
-| creativeFactoryTimeoutPreRenderContent | optional | integer | Controls how much time video and interstitial creatives have to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
-| storedAuctionResponse | optional | string | For testing and debugging. Get this value from your Prebid Server team. It signals Prebid Server to respond with a static response from the Prebid Server Database. Get this value from your Prebid Server team. See [more information on stored auction responses](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses). | "abc123-sar-test-320x50" |
-| pbsDebug | optional | boolean | Adds the debug flag (`test`:1) on the outbound http call to the Prebid Server. The `test` flag signals to the Prebid Server to emit the full resolved request and the full Bid Request and Bid Response to and from each bidder. | true |
+| host | required | object | Host.APPNEXUS, Host.RUBICON, Host.createCustomHost(PREBID_SERVER_AUCTION_ENDPOINT) | Host.createCustomHost<wbr>("https://prebidserver<wbr>.example.com<wbr>/openrtb2/auction") |
 
-### Global Methods
+Examples:
+
+```kotlin
+PrebidMobile.setPrebidServerHost(Host.APPNEXUS)
+PrebidMobile.setPrebidServerHost(Host.RUBICON)
+PrebidMobile.setPrebidServerHost(Host.createCustomHost(https://prebidserver.example.com/openrtb2/auction))
+```
+
+#### setCustomStatusEndpoint() (Android only)
+
+Signature:
+
+```kotlin
+    public static void setCustomStatusEndpoint(String url) {
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| url | required | string | Use this URL to check the status of Prebid Server. The default status endpoint is the PBS URL appended with '/status'. | "https://prebidserver<wbr>.example<wbr>.com/custom<wbr>/status" |
+
+#### setTimeoutMillis() (Android only)
+
+The Prebid SDK timeout. When this number of milliseconds passes, the Prebid SDK returns control to the ad server SDK to fetch an ad without Prebid bids. See the initialization page for [Android](/prebid-mobile/pbm-api/android/code-integration-android.html).
+
+#### setShareGeoLocation() (Android only)
+
+If this flag is true AND the app collects the user’s geographical location data, Prebid Mobile will send the user’s lat/long geographical location data to the Prebid Server. The default is false.
+
+#### setCustomPrebidServerUrl() (iOS only)
+
+Defines which Prebid Server to connect to. See the initialization pages for [iOS](/prebid-mobile/pbm-api/ios/code-integration-ios.html) or [Android](/prebid-mobile/pbm-api/android/code-integration-android.html).
+
+#### setIncludeWinnersFlag() (Android only)
+
+If `true`, Prebid sdk will add the `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . This is needed if you've set up line items in an ad server in "Send Top Bid" mode, as it's what creates the key value pairs like `hb_pb`. 
+
+Signature:
+
+```kotlin
+    public static void setIncludeWinnersFlag(boolean includeWinners)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| includeWinners | required | boolean | If `true`, Prebid sdk will add `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
+
+#### setIncludeBidderKeysFlag() (Android only)
+
+If `true`, Prebid sdk will add the `includebidderkeys` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . This is needed if you've set up line items in an ad server in "Send All Bids" mode, as it's what creates the key value pairs like `hb_pb_bidderA`. 
+
+Signature:
+
+```kotlin
+    public static boolean setIncludeBidderKeysFlag(boolean includeBidderKeys) {
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| includeBidderKeys | required | boolean | If `true`, Prebid sdk will add `includewinners` flag inside the targeting object described in [PBS Documentation](prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#targeting) . Default is `false`. | `true` |
+
+#### setStoredAuctionResponse() (Android only)
+
+For testing and debugging. Get this value from your Prebid Server team. It signals Prebid Server to respond with a static response from the Prebid Server Database. 
+See [more information on stored auction responses](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses).
+
+Signature:
+
+```kotlin
+public static void setStoredAuctionResponse(@Nullable String storedAuctionResponse)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| storedAuctionResponse | required | string | Key as defined by Prebid Server. Get this value from your Prebid Server team. | "abc123-sar-test-320x50" |
 
 #### addStoredBidResponse()
 
@@ -55,9 +179,94 @@ func clearStoredBidResponses()
 
 Parameters: none.
 
-#### addCustomHeader()
+#### setLogLevel (Android only)
 
-This method enables you to customize the HTTP call to Prebid Server.
+Controls the level of logging output to the console.
+
+Signature:
+
+```kotlin
+    public static void setLogLevel(LogLevel logLevel)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| logLevel | required | enum | The value can be ERROR, DEBUG, WARN, and NONE. The default is `.NONE`. | `.DEBUG` |
+
+#### setPbsDebug() (Android only)
+
+Adds the debug flag (`test`:1) on the outbound http call to the Prebid Server. The `test` flag signals to the Prebid Server to emit the full resolved request and the full Bid Request and Bid Response to and from each bidder.
+
+Signature:
+
+```kotlin
+public static void setPbsDebug(boolean pbsDebug)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| pbsDebug | required | boolean | Turn on/off debug mode. Defaults to `false`. | `true` |
+
+#### assignNativeAssetID() (Android only)
+
+Whether to automatically assign an assetID for a Native ad. Default is `false`.
+
+Signature:
+
+```kotlin
+    public static void assignNativeAssetID(boolean assignNativeAssetID) {
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| assignNativeAssetID | required | boolean | Whether to automatically assign an assetID for a Native ad. Defaults to `false`. | `true` |
+
+#### setCreativeFactoryTimeout() (Android only)
+
+Controls how long a banner creative has to load before it is considered a failure.
+
+Signature:
+
+```kotlin
+    public static void setCreativeFactoryTimeout(int creativeFactoryTimeout)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| creativeFactoryTimeout | required | integer | Controls how long a banner creative has to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+
+#### setCreativeFactoryTimeoutPreRenderContent() (Android only)
+
+Controls how much time video and interstitial creatives have to load before it is considered a failure.
+
+Signature:
+
+```kotlin
+    public static void setCreativeFactoryTimeoutPreRenderContent(int creativeFactoryTimeoutPreRenderContent)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| creativeFactoryTimeoutPreRenderContent | required | integer | Controls how much time video and interstitial creatives have to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+
+#### addCustomHeader() (iOS only)
+
+This method enables you to customize the HTTP call to Prebid Server. See [setCustomHeaders()](TBD) for the Android version.
 
 Signature:
 
@@ -73,6 +282,23 @@ Parameters:
 | name | required | string | Name of the custom header | "X-mycustomheader" |
 | value | required | string | Value for the custom header | "customvalue" |
 
+#### setCustomHeaders() (Android only)
+
+This method enables you to customize the HTTP call to Prebid Server. See [addCustomHeaders()](TBD) for the iOS version
+
+Signature:
+
+```kotlin
+    public static void setCustomHeaders(@Nullable HashMap<String, String> customHeaders)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| customHeaders | required | hashmap | Hashmap of custom headers | "X-mycustomheader: customvalue" |
+
 #### clearCustomHeaders()
 
 Allows you to clear any custom headers you have previously set.
@@ -84,6 +310,23 @@ func clearCustomHeaders()
 ```
 
 Parameters: none
+
+#### setCustomLogger() (Android only)
+
+TBD
+
+Signature:
+
+```kotlin
+    public static void setCustomLogger(@NonNull PrebidLogger logger)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| logger | required | ? | TBD | TBD |
 
 ## Consent Management
 
@@ -278,6 +521,10 @@ externalUserIdArray.append(ExternalUserId(source: "liveramp.com", identifier: "A
 externalUserIdArray.append(ExternalUserId(source: "sharedid.org", identifier: "111111111111", atype: 1))
 
 Prebid.shared.externalUserIdArray = externalUserIdArray
+```
+
+```kotlin
+setExternalUserIds(List<ExternalUserId> externalUserIds)
 ```
 
 ### Storing IDs in Local Storage

--- a/global-parameters-ios.md
+++ b/global-parameters-ios.md
@@ -1,191 +1,198 @@
 # Global Parameters iOS
 
+This page documents various global parameters you can set on the Prebid SDK. It describes the properties and methods of the Prebid SDK that allow you to supply important parameters to the header bidding auction.
 
-This page documents various global parameters you can set on the Prebid SDK. It describes the various properties and methods of the Prebid SDK, First-Party Data used for Targeting Ads, and consent options under various privacy regulations and User Identity API.  
-
-
-## Prebid SDK Properties and Methods
+## Prebid Global Properties and Methods
 
 The `Prebid` class is a singleton that enables you to apply global settings.
 
+### Global Properties
 
-### Properties
+(TBD - where are these set? Need an example. I reformatted this as a table.)
 
-`prebidServerAccountId`: [String] containing the Prebid Server account ID.
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| prebidServerAccountId | either | string | Your Prebid Server team will tell you whether this is required or not and if so, the value. | "abc123" |
+| prebidServerHost | required | string | This is a URL or system-defined Prebid Server host. It's where the Prebid SDK will send the auction information. Your Prebid Server team will tell you which value to use. The system-defined values are: (TBD) | "https://prebidserver.example.com/openrtb2/auction" |
+| shareGeoLocation | optional | boolean | If this flag is true AND the app collects the user’s geographical location data, Prebid Mobile will send the user’s geographical location data (TBD - lat/long?) to the Prebid Server. The default setting is false. | `true` |
+| logLevel | optional | TBD | This property controls the level of logging output to the console. The value can be (TBD). | TBD |
+| timeoutMillis | optional | integer | (SDK v1.2+) The Prebid SDK timeout. When this number of milliseconds passes, the Prebid SDK returns control to the ad server SDK to fetch an ad without Prebid bids. | 1000 |
+| creativeFactoryTimeout | optional | integer | Controls how long a banner creative has to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+| creativeFactoryTimeoutPreRenderContent | optional | integer | Controls how much time video and interstitial creatives have to load before it is considered a failure. (TBD - is this milliseconds? Need the default value) | 2000 |
+| storedAuctionResponse | optional | string | For testing and debugging. Get this value from your Prebid Server team. It signals Prebid Server to respond with a static response from the Prebid Server Database. Get this value from your Prebid Server team. See [more information on stored auction responses](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses). | "abc123-sar-test-320x50" |
+| pbsDebug | optional | boolean | Adds the debug flag (`test`:1) on the outbound http call to the Prebid Server. The `test` flag signals to the Prebid Server to emit the full resolved request and the full Bid Request and Bid Response to and from each bidder. | true |
 
-`prebidServerHost`: [String] This property is crucial as it contains the configuration for your Prebid Server host, with which the Prebid SDK will communicate. Depending on your specific needs, you can choose from the system-defined Prebid Server hosts or define your own custom Prebid Server host.
+### Global Methods
 
-`shareGeoLocation`: [Optiona]l [Bool]; if this flag is True AND the app collects the user’s geographical location data, Prebid Mobile will send the user’s geographical location data to the Prebid Server. Suppose this flag is false OR the app does not collect the user’s geographical location data. In that case, Prebid Mobile will not populate any user's geographical location information in the call to Prebid Server. The default setting is false.
+#### addStoredBidResponse()
 
-`logLevel`: This property controls the level of logging output to the console.
+Stored Bid Responses are for testing and debugging similar to Stored Auction Responses (see the Global Properties above). They signal Prebid Server to respond with a static pre-defined response, except Stored Bid Responses actually exercise the bidder adapter. For more information on how stored bid responses work, refer to the [Prebid Server endpoint doc](/prebid-server/endpoints/openrtb2/pbs-endpoint-auction.html#stored-responses). Your Prebid Server team will help you determine how best to setup test and debug.
 
-`timeoutMillis`: [Int]
+Signature:
 
-The Prebid timeout (available in SDK v1.2+), when set, returns control to the ad server SDK to fetch an ad once the specified timeout has elapsed. Because the Prebid SDK gets bids from the Prebid Server in one payload, setting the Prebid timeout too low can reduce demand, resulting in a potential negative revenue impact.
-
-`creativeFactoryTimeout`: [int] This parameter controls how long a banner creative has to load before it is considered a failure.
-
-`creativeFactoryTimeoutPreRenderContent`: This parameter controls how much time video and interstitial creatives have to load before it is considered a failure.
-
-`storedAuctionResponse`: Set as type string, stored auction responses signal Prebid Server to respond with a static response matching the storedAuctionResponse found in the Prebid Server Database, useful for debugging and integration testing. No bid requests will be sent to bidders when a matching storedAuctionResponse is found. For more information on how stored auction responses work, refer to the [written description on github issue 133.](https://github.com/prebid/prebid-mobile-android/issues/133)
-
-`pbsDebug:` adds the debug flag (“test”:1) on the outbound http call to the Prebid Server. The test:1 flag signals to the Prebid Server to emit the full resolved request (resolving any Stored Request IDs) and the full Bid Request and Bid Response to and from each bidder.
-
-
-### Methods
-
-
-#### Stored Responses
-
-`addStoredBidResponse`: This method takes two parameters
-
-
-
-* `bidder`: Bidder name as defined by Prebid Server bid adapter of type string.
-* `responseId`: Configuration ID used in the Prebid Server Database to store static bid responses.
-
-Stored Bid Responses are similar to Stored Auction Responses in that they signal to Prebid Server to respond with a static pre-defined response, except Stored Bid Responses is done at the bidder level, with bid requests sent out for any bidders not specified in the bidder parameter. For more information on how stored auction responses work, refer to [github issue 133](https://github.com/prebid/prebid-mobile-android/issues/133).
-
-
-```
+```swift
 func addStoredBidResponse(bidder: String, responseId: String)
 ```
 
+Parameters:
 
-`clearStoredBidResponses`: This method clears any stored bid responses. It doesn’t take any parameters.
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| bidder | required | string | Bidder name as defined by Prebid Server | "bidderA" |
+| responseId | required | string | ID used in the Prebid Server Database. Get this value from your Prebid Server team. | "abc123-sbr-test-300x250" |
 
-Custom Headers
+#### clearStoredBidResponses()
 
-`addCustomHeader`: This method enables you to customize the HTTP call to the prebid server. It takes two parameters
+This method clears any stored bid responses. It doesn’t take any parameters.
 
+Signature:
 
+```swift
+func clearStoredBidResponses()
+```
 
-* `name`: a name for the custom header
-* `value`: a value for the custom header
+Parameters: none.
 
-`clearCustomHeaders`: Allows you to clear any custom headers you have previously set.
+#### addCustomHeader()
 
+This method enables you to customize the HTTP call to Prebid Server.
 
-### SDK Properties and Methods Example usage
+Signature:
 
+```swift
+func addCustomHeader(name: String, value: String)
+```
+
+Parameters:
+
+{: .table .table-bordered .table-striped }
+| Parameter | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | required | string | Name of the custom header | "X-mycustomheader" |
+| value | required | string | Value for the custom header | "customvalue" |
+
+#### clearCustomHeaders()
+
+Allows you to clear any custom headers you have previously set.
+
+Signature:
+
+```swift
+func clearCustomHeaders()
+```
+
+Parameters: none
 
 ## Consent Management
 
-_This section describes how publishers can provide info on user consent to the SDK and how SDK behaves under different kinds of restrictions._
+This section describes how app developers can provide info on user consent to the Prebid SDK and how SDK behaves under different kinds of restrictions.
 
+### iOS App Tracking Transparency
 
-### App Tracking Transparency
-
-You should follow Apple's Guidelines on implementing [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency). The Prebid SDK automatically sends ATT signals, so no prebid-specific work is required.
-
+You should follow Apple's Guidelines on implementing [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency). The Prebid SDK automatically sends ATT signals, so no Prebid-specific work is required.
 
 ### GDPR
 
-There are two ways to provide information on user consent to the Prebid SDK according to The Transparency & Consent Framework (TCF)
+There are two ways to provide information on user consent to the Prebid SDK according to the [IAB's Transparency & Consent Framework (TCF)](https://iabeurope.eu/understanding-the-upcoming-transparency-consent-framework-v2-2/)
 
+- Explicitly via Prebid SDK API: publishers can provide TCF data via Prebid SDK’s Targeting API
+- Implicitly set through the CMP: Prebid SDK reads the TCF data stored in the `UserDefaults`. This is the preferred approach.
 
-
-* Explicitly via SDK API: publishers can provide TCF data via SDK’s Targeting API
-* Implicitly set through the CMP: SDK reads the TCF data stored in the `UserDefaults`
-
-**Important**: The SDK explicitly prioritizes the values set through the API over those stored by the CMP and treats the latter as a fallback.  If the publisher provides TCF data both ways, the values set through the API will be sent to the PBS, and values stored by the CMP will be ignored. 
-
+**Important**: The Prebid SDK explicitly prioritizes the values set through the API over those stored by the CMP.  If the publisher provides TCF data both ways, the values set through the API will be sent to the PBS, and values stored by the CMP will be ignored. 
 
 #### Setting GDPR Values with the API
 
-SDK provides three properties to set the TCF values explicitly, though this method is not preferred. Ideally, the Consent Management Platform will set these values – see the next section.
+Prebid SDK provides three properties to set TCF consent values explicitly, though this method is not preferred. Ideally, the Consent Management Platform will set these values – see the next section.
 
 If you need to set the values directly, here's how to indicate that the user is subject to GDPR:
 
 Swift: 
 
-
-```
+```swift
 Targeting.shared.subjectToGDPR = false
 ```
-
 
 To provide the consent string:
 
 Swift:
 
-
-```
+```swift
 Targeting.shared.gdprConsentString = "BOMyQRvOMyQRvABABBAAABAAAAAAEA"
 ```
-
 
 To set the purpose consent: 
 
 Swift:
 
-
-```
+```swift
 Targeting.shared.purposeConsents = "100000000000000000000000"
 ```
 
-
-
 #### Getting Consent Values from the CMP
 
-SDK reads the values for the following keys from the `UserDefaults` object 
+Prebid SDK reads the values for the following keys from the `UserDefaults` (iOS) or `SharedPreferences` (Android) object:
 
-
-
-* **IABTCF_gdprApplies** - indicates whether the user is subject to GDPR
-* **IABTCF_TCString** - full encoded TC string
-* **IABTCF_PurposeConsents** - indicates the consent status for the purpose. 
+- **IABTCF_gdprApplies** - indicates whether the user is subject to GDPR
+- **IABTCF_TCString** - full encoded TC string
+- **IABTCF_PurposeConsents** - indicates the consent status for the purpose. 
 
 For more detailed information, read the [In-App Details section](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20CMP%20API%20v2.md#in-app-details) of the TCF.
 
-Here is an example of a `UserDefaults` file with TCF signals: 
-
 **Note**: Publishers shouldn’t explicitly assign values for these keys (unless they have a custom-developed CMP).  It is a privilege of the Consent Management Provider (CMP) SDKs. If the publisher wants to provide this data to the Prebid SDK, they should use the explicit APIs described above.
 
-Here are several essential implementation details on how SDK processes CMP values:
+Here's how Prebid SDK processes CMP values:
 
+- It reads CMP values during the initialization and on each bid request, so the latest value is always used.
+- It doesn’t verify or validate CMP values in any way
 
+### CCPA / USP
 
-* Prebid SDK reads CMP values from the `UserDefaults `during the initialization 
-* Prebid SDK doesn’t verify or validate CMP values in any way
-* Prebid SDK reads CMP values for each bid request, so the latest value is always used.
+The California Consumer Protection Act drove the IAB to implement the "US Privacy" protocol.
 
+Prebid SDK reads and sends USP/CCPA signals according to the [US Privacy User Signal Mechanism](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/USP%20API.md) and [OpenRTB extension](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/7f4f1b2931cca03bd4d91373bbf440071823f257/CCPA/OpenRTB%20Extension%20for%20USPrivacy.md). 
 
-### CCPA
-
-Prebid SDK reads and sends CCPA signals according to the [US Privacy User Signal Mechanism](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/USP%20API.md) and [OpenRTB extension](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/7f4f1b2931cca03bd4d91373bbf440071823f257/CCPA/OpenRTB%20Extension%20for%20USPrivacy.md). 
-
-SDK reads the value for the `IABUSPrivacy_String` key from the `UserDefaults` and sends it in the `regs.ext.us_privacy` object of the OpenRTB request.
-
+Prebid SDK reads the value for the `IABUSPrivacy_String` key from the `UserDefaults` (iOS) or `SharedPreferences` (Android) and sends it in the `regs.ext.us_privacy` object of the OpenRTB request.
 
 ### COPPA
 
-Prebid SDK follows the OpenRTB 2.6 spec and provides an API to indicate whether the current user falls under COPPA regulation. Publishers can set the respective flag using the targeting API: 
+The Children's Online Privacy Protection Act of the United States is a way for content producers to declare their content is aimed at children, which invokes additional privacy protections.
+
+Prebid SDK follows the OpenRTB 2.6 spec and provides an API to indicate whether the current content falls under COPPA regulation. Publishers can set the respective flag using the targeting API: 
 
 Swift:
 
-
-```
+```swift
 Targeting.shared.subjectToCOPPA = true
 ```
 
+Prebid SDK passes this flag in the `regs.coppa` object of the bid requests.
 
-SDK passes this flag in the `regs.coppa` object of the bid requests. 
+If you're app developer setting this COPPA flag, we recommend you also:
 
-SDK relies on the section “**7.5 COPPA Regulation Flag**” of the OpenRTB spec and does not refrain from reading user and device data since suppressing these fields should be an exchange obligation. 
-
+- set the `shareGeoLocation` property to false
+- avoid passing any sensitive first party data
 
 ### GPP
 
-Note: GPP is supported starting from version Prebid SDK 2.0.6.
+A Consent Management Platform (CMP) utilizing [IAB's Global Privacy Protocol](https://iabtechlab.com/gpp/) is a comprehensive way for apps to manage user consent across multiple regulatory environments.
 
-Prebid SDK reads and sends GPP signals according to the [CMP API Specification](https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Core/CMP%20API%20Specification.md) and OpenRTB 2.6 spec (so far [GPP in proposal](https://github.com/prebid/prebid-server/issues/2442)). 
+Since version 2.0.6, Prebid SDK reads and sends GPP signals:
 
-SDK reads the value for the `IABGPP_HDR_GppString` key in the `UserDefaults` and sends it in the `regs.gpp` object of the OpenRTB request.
+- The GPP string is read from IABGPP_HDR_GppString in `UserDefaults` (iOS) or `SharedPreferences` (Android). It is sent to Prebid Server on `regs.gpp`.
+- The GPP Section ID is likewise read from IABGPP_GppSID. It is sent to Prebid Server on `regs.gpp_sid`.
 
-## First Party User Data
+## First Party Data
 
-Prebid provides following functions to manage First Party User Data:
+First Party Data (FPD) is information about the app or user known by the developer that may be of interest to advertisers. 
+
+- User FPD includes details about a specific user like "frequent user" or "job title". This data if often subject to regulatory control, so needs to be specified as user-specific data. Note that some attributes like health status are limited in some regions. App developers are strongly advised to speak with their legal counsel before passing User FPD.
+- Inventory FPD includes details about the particular part of the app where the ad will displayed like "sports/basketball" or "editor 5-star rating".
+
+### User FPD
+
+Prebid SDK provides following functions to manage First Party User Data:
 
 ```swift
 func addUserData(key: String, value: String)
@@ -203,7 +210,7 @@ Example:
 Targeting.shared.addUserData(key: "globalUserDataKey1", value: "globalUserDataValue1")
 ```
 
-### First Party Inventory (Context) Data
+### Inventory FPD
 
 Prebid provides following functions to manage First Party Inventory Data:
 
@@ -223,9 +230,9 @@ Example:
 Targeting.shared.addContextData(key: "globalContextDataKey1", value: "globalContextDataValue1")
 ```
 
-### Access Control
+### Controlling Bidder Access to FPD
 
-The First Party Data Access Control List provides a methods to restrict access to first party data to a supplied list of bidders.
+Prebid Server will let you control which bidders are allowed access to First Party Data. Prebid SDK collects this an Access Control List with the following methods:
 
 ```swift
 func addBidderToAccessControlList(_ bidderName: String)
@@ -241,24 +248,24 @@ Example:
 Targeting.shared.addBidderToAccessControlList(Prebid.bidderNameRubiconProject)
 ```
 
-## User Identity API
+## User Identity
 
-Prebid SDK supports two interfaces to pass / maintain User IDs and ID vendor details:
+Mobile apps traditionally rely on IDFA-type device IDs for advertising, but there are other User ID systems available to app developers and more will be made available in the future. Prebid SDK supports two ways to maintain User ID details:
 
-* Real-time in Prebid SDK's API field externalUserIdArray
-* Store User Id(s) in local storage
+- A global property - in this approach, the app developer sets the IDs while initializing the Prebid SDK. This data persists only for the user session.
+- Local storage - the developer can choose to store the IDs persistently in local storage and Prebid SDK will utilize them on each bid request.
 
-Any identity vendor's details in local storage will be sent over to Prebid Server as is, unadulterated. If data is sent in the API and entered into local storage, the API detail will prevail.
+Any identity vendor's details in local storage will be sent to Prebid Server unadulterated. If user IDs are set both in the property and entered into local storage, the property data will prevail.
 
-### Prebid SDK API Access
+### Storing IDs in a Property
 
-Prebid SDK supports passing an array of UserID(s) at auction time in the field externalUserIdArray, which is globally scoped. Setting the externalUserIdArray object once per user session is sufficient, as these values would be used in all consecutive ad auctions in the same session.
+Prebid SDK supports passing an array of UserID(s) at auction time in the Prebid global field `externalUserIdArray`. Setting the `externalUserIdArray` object once per user session is sufficient unless one of the values changes.
 
 ```swift
 public var externalUserIdArray = [ExternalUserId]()
 ```
 
-**Exmaples**
+**Examples**
 
 ```swift
 // User Id from External Third Party Sources
@@ -268,16 +275,16 @@ externalUserIdArray.append(ExternalUserId(source: "adserver.org", identifier: "1
 externalUserIdArray.append(ExternalUserId(source: "netid.de", identifier: "999888777")) 
 externalUserIdArray.append(ExternalUserId(source: "criteo.com", identifier: "_fl7bV96WjZsbiUyQnJlQ3g4ckh5a1N")) 
 externalUserIdArray.append(ExternalUserId(source: "liveramp.com", identifier: "AjfowMv4ZHZQJFM8TpiUnYEyA81Vdgg"))
-externalUserIdArray.append(ExternalUserId(source: "sharedid.org", identifier: "111111111111", atype: 1, ext: ["third" : "01ERJWE5FS4RAZKG6SKQ3ZYSKV"]))
+externalUserIdArray.append(ExternalUserId(source: "sharedid.org", identifier: "111111111111", atype: 1))
 
 Prebid.shared.externalUserIdArray = externalUserIdArray
 ```
 
-### Local Storage
+### Storing IDs in Local Storage
 
-Prebid SDK provides a local storage interface to set, retrieve, or update an array of user IDs with associated identity vendor details. Prebid SDK will retrieve and pass User IDs and ID vendor details to PBS if values are present in local storage. The main difference between the Prebid API interface and the local storage interface is data storage persistence. Local Storage data will persist across user sessions, whereas the Prebid API interface (externalUserIdArray) persists only for the user session. If a vendor's details are passed into local storage and the Prebid API simultaneously, the Prebid  API data (externalUserIdArray) will prevail.
+Prebid SDK provides a local storage interface to set, retrieve, or update an array of user IDs with associated identity vendor details. It will then retrieve and pass these User IDs to Prebid Server on each auction, even on the next user session.
 
-Prebid SDK Provides five functions to handle User ID details:
+Prebid SDK Provides several functions to handle User ID details within the local storage:
 
 ```swift
 public func storeExternalUserId(_ externalUserId: ExternalUserId)
@@ -295,7 +302,7 @@ public func removeStoredExternalUserIds()
 
 ```swift
 //Set External User ID
-Targeting.shared.storeExternalUserId(ExternalUserId(source: "sharedid.org", identifier: "111111111111", atype: 1, ext: ["third" : "01ERJWE5FS4RAZKG6SKQ3ZYSKV"]))
+Targeting.shared.storeExternalUserId(ExternalUserId(source: "sharedid.org", identifier: "111111111111", atype: 1))
 
 //Get External User ID
 let externalUserIdSharedId = Targeting.shared.fetchStoredExternalUserId("sharedid.org")


### PR DESCRIPTION
Global parameters open items

- timeoutMillis - is this sent as tmax? Should be ext.tmaxmax.
- Android lacks locationUpdatesEnabled equiv
- Different log levels
- iOS doesn’t support sendMraidSupportParams
- Android has 3 properties which seems odd since everything else has setter/getters: isCoppaEnabled, useExternalBrowser, sendMraidSupportParams
- Am guessing that Android useExternalBrowser is equivalent to iOS useExternalClickthroughBrowser?
- Android doesn’t have impClickbrowserType
- iOS addCustomHeader() vs Android setCustomHeaders()
- Android setCustomLogger vs iOS debugLogFileEnabled
- iOS buyerUID is not an appropriate field, Android setBuyerId
- What is IOS “userCustomData”?
- How does Prebid.shared.externalUserIdArray differ from ‘eids’?
- What is targeting.purposeConsents?
- What is setCustomParams - user/inv/both?
- iOS set YOB vs android setUserAge
- There appears to be Gender “other” in iOS but not Android
- For the record, eid stands for “extended id”, not “external id”
- Android addExtData - user/site?
- Comment for addExtKeyword says “imp[].ext.context.keywords” - not correct
- iOS subjectToCOPPA vs android setSubjectToCOPPA
- What is setUserCustomData? “Optional feature to pass bidder data that was set in the exchange’s cookie. “
- What is Targeting.shared.addBidderToAccessControlList(Prebid.bidderNameRubiconProject) ?
- What is userExt (Android) as compared to userData?
